### PR TITLE
엘베 여러 대 운용

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -18,6 +18,13 @@ def action(token, cmds):
     uri = url + '/action'
     return requests.post(uri, headers={'X-Auth-Token': token}, json={'commands': cmds}).json()
 
+# 태울 승객 리스트에서 태운 승객들을 제거함
+def remove_enter_call(oncall_data, enter_call_list):
+    for enter_id in enter_call_list:
+        for call in oncall_data['calls']:
+            if call['id'] == enter_id:
+                oncall_data['calls'].remove(call)
+                break
 
 # 엘베 최대 수용 8명이 다 찼는지 여부
 def b_elev_full(elevator):
@@ -115,6 +122,9 @@ def enter_call(oncall_data, elevator):
         if call['start'] == elevator['floor']:
             if len(elevator['passengers']) + len(enter_call_list) < 8: # 엘베 정원을 초과하지 않도록 태울 승객 리스트를 추가
                 enter_call_list.append(call['id'])
-            else: return enter_call_list
+            else:
+                remove_enter_call(oncall_data, enter_call_list) # 태울 승객 리스트에서 태운 승객들을 제거함
+                return enter_call_list
+    remove_enter_call(oncall_data, enter_call_list) # 태울 승객 리스트에서 태운 승객들을 제거함
     return enter_call_list
 

--- a/p0_test.py
+++ b/p0_test.py
@@ -3,7 +3,7 @@ import lib
 def p0_simulator():
     user = 'tester'
     problem = 0
-    count = 1
+    count = 4
 
     ret = lib.start(user, problem, count)
     token = ret['token']

--- a/p1_test.py
+++ b/p1_test.py
@@ -3,7 +3,7 @@ import lib
 def p1_simulator():
     user = 'tester'
     problem = 1
-    count = 1
+    count = 3
 
     ret = lib.start(user, problem, count)
     token = ret['token']
@@ -24,16 +24,16 @@ def p1_simulator():
 
 
             if elevator.get('status') == 'STOPPED':
-                # 현재층에 콜이 있으면 OPEN 명령 내림
+                # 엘베가 멈춘 상태에서, 현재층에 수행할 콜이 있으면 OPEN 명령 내림
                 if lib.b_exit_call(elevator) or lib.b_enter_call(oncall_data, elevator):
                     tmp_command['command'] = 'OPEN'
 
-                # 현재, 위, 아래층에 태울 콜이 없다면, STOP
+                # 엘베가 멈춘 상태에서, 현재, 위, 아래층에 태울 콜이 없다면, STOP
                 elif not lib.b_upstairs_call(oncall_data, elevator) and not lib.b_downstairs_call(oncall_data, elevator):
                     tmp_command['command'] = 'STOP'
                     tmp_elevator[elevator['id']] = 'STOPPED'
 
-                # 멈추기 전에 올라가고 있는 상태였을 때, 위층에 콜이 있다면 UP, 아래층에 콜 있다면 DOWN, 위아래 둘 다 콜이 없다면 STOP
+                # 엘베가 멈춘 상태에서, 멈추기 전에 올라가고 있는 상태였을 때, 위층에 콜이 있다면 UP, 아래층에 콜 있다면 DOWN
                 elif tmp_elevator[elevator['id']] == 'UPWARD':
                     if lib.b_upstairs_call(oncall_data, elevator):
                         tmp_command['command'] = 'UP'
@@ -42,7 +42,7 @@ def p1_simulator():
                         tmp_command['command'] = 'DOWN'
                         tmp_elevator[elevator['id']] = 'DOWNWARD'
 
-                # 멈추기 전에 내려가고 있는 상태였을 때, 아래층에 콜이 있다면 DOWN, 위층에 콜이 있다면 UP, 위아래 둘다 콜이 없다면 STOP
+                # 엘베가 멈춘 상태에서, 멈추기 전에 내려가고 있는 상태였을 때, 아래층에 콜이 있다면 DOWN, 위층에 콜이 있다면 UP
                 elif tmp_elevator[elevator['id']] == 'DOWNWARD':
                     if lib.b_downstairs_call(oncall_data, elevator):
                         tmp_command['command'] = 'DOWN'
@@ -51,7 +51,7 @@ def p1_simulator():
                         tmp_command['command'] = 'UP'
                         tmp_elevator[elevator['id']] = 'UPWARD'
 
-                # 콜이 없어서 전에도 멈춘 상태였었고, 위, 아래 층에 동시 콜이 생기면 더 가까운 쪽으로 UP or DOWN, 위층에만 콜이 생기면 UP, 아래층에만 콜이 생기면 DOWN
+                # 엘베가 멈춘 상태에서, 콜이 없어서 전에도 멈춘 상태였었고, 위, 아래 층에 동시 콜이 생기면 더 가까운 쪽으로 UP or DOWN, 위층에만 콜이 생기면 UP, 아래층에만 콜이 생기면 DOWN
                 elif tmp_elevator[elevator['id']] == 'STOPPED':
                     if lib.b_upstairs_call(oncall_data, elevator) and lib.b_downstairs_call(oncall_data, elevator):
                         tmp_command['command'] = lib.closer_call_move(oncall_data, elevator)
@@ -66,41 +66,49 @@ def p1_simulator():
 
 
             elif elevator.get('status') == 'UPWARD':
-                # 현재 층에 콜이 있다면, STOP
+                # 엘베가 올라가던 중에, 현재 층에 수행할 콜이 있다면, STOP
                 if lib.b_exit_call(elevator) or lib.b_enter_call(oncall_data, elevator):
                     tmp_command['command'] = 'STOP'
 
-                # 현재 층에 콜이 없다면, UP
-                else:
+                # 엘베가 올라가던 중에, 위층에 수행할 콜이 있다면, UP
+                elif lib.b_upstairs_call(oncall_data, elevator):
                     tmp_command['command'] = 'UP'
                     tmp_elevator[elevator['id']] = 'UPWARD'
 
+                # 엘베가 올라가던 중에, 현재와 위층에 수행할 콜이 없고, 아래층에 수행할 콜이 있거나 없는 경우 STOP
+                else:
+                    tmp_command['command'] = 'STOP'
+                    tmp_elevator[elevator['id']] = 'STOPPED'
 
             elif elevator.get('status') == "DOWNWARD":
-                # 현재 층에 콜이 있다면, STOP
+                # 엘베가 내려가던 중에, 현재 층에 수행할 콜이 있다면, STOP
                 if lib.b_exit_call(elevator) or lib.b_enter_call(oncall_data, elevator):
                     tmp_command['command'] = 'STOP'
 
-                # 현재 층에 콜이 없다면, DOWN
-                else:
+                # 엘베가 내려가던 중에, 아래층에 수행할 콜이 있다면, DOWN
+                elif lib.b_downstairs_call(oncall_data, elevator):
                     tmp_command['command'] = 'DOWN'
                     tmp_elevator[elevator['id']] = 'DOWNWARD'
 
+                # 엘베가 내려가던 중에, 현재와 아래층에 수행할 콜이 없고, 위층에 수행할 콜이 있거나 없는 경우 STOP
+                else:
+                    tmp_command['command'] = 'STOP'
+                    tmp_elevator[elevator['id']] = 'STOPPED'
 
             elif elevator.get('status') == 'OPENED':
-                # 내려줄 콜 있으면 EXIT
+                # 문열렸을 때, 내려줄 콜이 있으면 EXIT
                 if lib.b_exit_call(elevator):
                     tmp_command['command'] = 'EXIT'
                     exit_list = lib.exit_call(elevator)
                     tmp_command['call_ids'] = exit_list
 
-                # 태울 콜 있으면 ENTER
+                # 문열렸을 때, 태울 콜이 있으면 ENTER
                 elif lib.b_enter_call(oncall_data, elevator):
                     tmp_command['command'] = 'ENTER'
                     enter_list = lib.enter_call(oncall_data, elevator)
                     tmp_command['call_ids'] = enter_list
 
-                # 내려주거나 태울 콜 없으면 CLOSE
+                # 문열렸을 때, 수행할 콜이 없으면 CLOSE
                 else: tmp_command['command'] = 'CLOSE'
 
             command_list.append(tmp_command)
@@ -108,6 +116,7 @@ def p1_simulator():
         cmds = {}
         cmds['commands'] = command_list
         print(lib.action(token, cmds['commands']))
+
 
 
 if __name__ == '__main__':

--- a/p2_test.py
+++ b/p2_test.py
@@ -3,7 +3,7 @@ import lib
 def p2_simulator():
     user = 'tester'
     problem = 2
-    count = 1
+    count = 4
 
     ret = lib.start(user, problem, count)
     token = ret['token']
@@ -24,16 +24,16 @@ def p2_simulator():
 
 
             if elevator.get('status') == 'STOPPED':
-                # 현재층에 콜이 있으면 OPEN 명령 내림
+                # 엘베가 멈춘 상태에서, 현재층에 수행할 콜이 있으면 OPEN 명령 내림
                 if lib.b_exit_call(elevator) or lib.b_enter_call(oncall_data, elevator):
                     tmp_command['command'] = 'OPEN'
 
-                # 현재, 위, 아래층에 태울 콜이 없다면, STOP
+                # 엘베가 멈춘 상태에서, 현재, 위, 아래층에 태울 콜이 없다면, STOP
                 elif not lib.b_upstairs_call(oncall_data, elevator) and not lib.b_downstairs_call(oncall_data, elevator):
                     tmp_command['command'] = 'STOP'
                     tmp_elevator[elevator['id']] = 'STOPPED'
 
-                # 멈추기 전에 올라가고 있는 상태였을 때, 위층에 콜이 있다면 UP, 아래층에 콜 있다면 DOWN, 위아래 둘 다 콜이 없다면 STOP
+                # 엘베가 멈춘 상태에서, 멈추기 전에 올라가고 있는 상태였을 때, 위층에 콜이 있다면 UP, 아래층에 콜 있다면 DOWN
                 elif tmp_elevator[elevator['id']] == 'UPWARD':
                     if lib.b_upstairs_call(oncall_data, elevator):
                         tmp_command['command'] = 'UP'
@@ -42,7 +42,7 @@ def p2_simulator():
                         tmp_command['command'] = 'DOWN'
                         tmp_elevator[elevator['id']] = 'DOWNWARD'
 
-                # 멈추기 전에 내려가고 있는 상태였을 때, 아래층에 콜이 있다면 DOWN, 위층에 콜이 있다면 UP, 위아래 둘다 콜이 없다면 STOP
+                # 엘베가 멈춘 상태에서, 멈추기 전에 내려가고 있는 상태였을 때, 아래층에 콜이 있다면 DOWN, 위층에 콜이 있다면 UP
                 elif tmp_elevator[elevator['id']] == 'DOWNWARD':
                     if lib.b_downstairs_call(oncall_data, elevator):
                         tmp_command['command'] = 'DOWN'
@@ -51,7 +51,7 @@ def p2_simulator():
                         tmp_command['command'] = 'UP'
                         tmp_elevator[elevator['id']] = 'UPWARD'
 
-                # 콜이 없어서 전에도 멈춘 상태였었고, 위, 아래 층에 동시 콜이 생기면 더 가까운 쪽으로 UP or DOWN, 위층에만 콜이 생기면 UP, 아래층에만 콜이 생기면 DOWN
+                # 엘베가 멈춘 상태에서, 콜이 없어서 전에도 멈춘 상태였었고, 위, 아래 층에 동시 콜이 생기면 더 가까운 쪽으로 UP or DOWN, 위층에만 콜이 생기면 UP, 아래층에만 콜이 생기면 DOWN
                 elif tmp_elevator[elevator['id']] == 'STOPPED':
                     if lib.b_upstairs_call(oncall_data, elevator) and lib.b_downstairs_call(oncall_data, elevator):
                         tmp_command['command'] = lib.closer_call_move(oncall_data, elevator)
@@ -66,41 +66,49 @@ def p2_simulator():
 
 
             elif elevator.get('status') == 'UPWARD':
-                # 현재 층에 콜이 있다면, STOP
+                # 엘베가 올라가던 중에, 현재 층에 수행할 콜이 있다면, STOP
                 if lib.b_exit_call(elevator) or lib.b_enter_call(oncall_data, elevator):
                     tmp_command['command'] = 'STOP'
 
-                # 현재 층에 콜이 없다면, UP
-                else:
+                # 엘베가 올라가던 중에, 위층에 수행할 콜이 있다면, UP
+                elif lib.b_upstairs_call(oncall_data, elevator):
                     tmp_command['command'] = 'UP'
                     tmp_elevator[elevator['id']] = 'UPWARD'
 
+                # 엘베가 올라가던 중에, 현재와 위층에 수행할 콜이 없고, 아래층에 수행할 콜이 있거나 없는 경우 STOP
+                else:
+                    tmp_command['command'] = 'STOP'
+                    tmp_elevator[elevator['id']] = 'STOPPED'
 
             elif elevator.get('status') == "DOWNWARD":
-                # 현재 층에 콜이 있다면, STOP
+                # 엘베가 내려가던 중에, 현재 층에 수행할 콜이 있다면, STOP
                 if lib.b_exit_call(elevator) or lib.b_enter_call(oncall_data, elevator):
                     tmp_command['command'] = 'STOP'
 
-                # 현재 층에 콜이 없다면, DOWN
-                else:
+                # 엘베가 내려가던 중에, 아래층에 수행할 콜이 있다면, DOWN
+                elif lib.b_downstairs_call(oncall_data, elevator):
                     tmp_command['command'] = 'DOWN'
                     tmp_elevator[elevator['id']] = 'DOWNWARD'
 
+                # 엘베가 내려가던 중에, 현재와 아래층에 수행할 콜이 없고, 위층에 수행할 콜이 있거나 없는 경우 STOP
+                else:
+                    tmp_command['command'] = 'STOP'
+                    tmp_elevator[elevator['id']] = 'STOPPED'
 
             elif elevator.get('status') == 'OPENED':
-                # 내려줄 콜 있으면 EXIT
+                # 문열렸을 때, 내려줄 콜이 있으면 EXIT
                 if lib.b_exit_call(elevator):
                     tmp_command['command'] = 'EXIT'
                     exit_list = lib.exit_call(elevator)
                     tmp_command['call_ids'] = exit_list
 
-                # 태울 콜 있으면 ENTER
+                # 문열렸을 때, 태울 콜이 있으면 ENTER
                 elif lib.b_enter_call(oncall_data, elevator):
                     tmp_command['command'] = 'ENTER'
                     enter_list = lib.enter_call(oncall_data, elevator)
                     tmp_command['call_ids'] = enter_list
 
-                # 내려주거나 태울 콜 없으면 CLOSE
+                # 문열렸을 때, 수행할 콜이 없으면 CLOSE
                 else: tmp_command['command'] = 'CLOSE'
 
             command_list.append(tmp_command)


### PR DESCRIPTION
어느 한 엘베가 A라는 승객을 태운 시점에서, 다른 엘베가 A라는 승객을 태우는 명령을 내리면 오류가 발생합니다. 태운 승객은 탑승을 기다리는 승객 리스트에서 제거합니다. 이로써 엘리베이터를 여러 대 운용할 수 있습니다. 